### PR TITLE
fixed User Agent Problem that caused response code 529

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,11 @@ http.createServer(async (req, res) => {
 			
 			const promise: Promise<string> = new Promise((resolve, reject) => {
 				let imgData = '';
-				http.get(target, null,res => {
+				const options = {
+					headers: { 'User-Agent': 'OSMProxy' }
+				};
+				
+				http.get(target, options, res => {
 					if (res.statusCode === 200) { 
 						res.setEncoding('binary');
 						res.on('data', chunck => imgData += chunck)


### PR DESCRIPTION
Since 2020 OSM Tile Server doesn't allow requests without User Agent. 
Response code was always 529 - Too many requests. 
By adding the User Agent to the get Request the problem is fixed again.